### PR TITLE
fix bin agreement

### DIFF
--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -152,7 +152,7 @@ netplot <- function(g,
             y <- rep(legend.y, length(col.legend))
             points(x, y, pch=15, col=col.legend, cex=2)
 
-            idx <- c(1, seq(4, col.bin-1, by=3), col.bin)
+            idx <- c(1, seq(4, length(col.legend)-1, by=3), length(col.legend))
             text(x=x[idx],
                  y=rep(legend.y-0.05, length(idx)),
                  label=lbs[idx],

--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -148,8 +148,8 @@ netplot <- function(g,
             lbs <- hist(fc, breaks=col.bin-1, plot=FALSE)$breaks
             col.legend <- get.col.scale(lbs)
 
-            x <- seq(from=legend.x, by=0.03, length.out=col.bin)
-            y <- rep(legend.y, col.bin)
+            x <- seq(from=legend.x, by=0.03, length.out=length(col.legend))
+            y <- rep(legend.y, length(col.legend))
             points(x, y, pch=15, col=col.legend, cex=2)
 
             idx <- c(1, seq(4, col.bin-1, by=3), col.bin)


### PR DESCRIPTION
Number of breaks provided to hist(.) is taken only as a suggestion and may not match the resulting number of breaks.  I ran in a few cases when green color was looped to the right side (where supposed to be only red).