### PR TITLE
Adding other arguments to the plot

### DIFF
--- a/R/cnetplot.R
+++ b/R/cnetplot.R
@@ -134,14 +134,14 @@ netplot <- function(g,
                     fixed=TRUE,
                     col.bin=10,
                     legend.x=1,
-                    legend.y=1) {
+                    legend.y=1, ...) {
     if (fixed){
         plot.igraph(g,
                     vertex.label.font=vertex.label.font,
                     vertex.label.color=vertex.label.color,
                     vertex.label.cex=vertex.label.cex,
                     vertex.frame.color=V(g)$color,
-                    layout=layout)
+                    layout=layout, ...)
         ## add legend
         if (!is.null(foldChange)) {
             ## gn <- V(g)$name


### PR DESCRIPTION
This should (I haven't tested) fix the error when one wants to set a title on the plot generated or some other arguments:

Error in netplot(g, vertex.label.font = vertex.label.font, vertex.label.color = "black",  : 
  unused argument (main = "Title of the plot")